### PR TITLE
[Postponed] Rust: Add `deny(unsafe_op_in_unsafe_fn)` lint.

### DIFF
--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -1,6 +1,9 @@
-/**
+/*
  * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
  */
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
 mod types;
 
 use crate::scripts_container::get_script;

--- a/glide-core/src/client/reconnecting_connection.rs
+++ b/glide-core/src/client/reconnecting_connection.rs
@@ -1,6 +1,9 @@
-/**
+/*
  * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
  */
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use super::{NodeAddress, TlsMode};
 use crate::retry_strategies::RetryStrategy;
 use futures_intrusive::sync::ManualResetEvent;

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -1,6 +1,9 @@
-/**
+/*
  * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
  */
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use super::get_redis_connection_info;
 use super::reconnecting_connection::ReconnectingConnection;
 use super::{ConnectionRequest, NodeAddress, TlsMode};

--- a/glide-core/src/client/types.rs
+++ b/glide-core/src/client/types.rs
@@ -2,6 +2,8 @@
  * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
  */
 
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use std::time::Duration;
 
 #[cfg(feature = "socket-layer")]

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -1,6 +1,9 @@
-/**
+/*
  * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
  */
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use redis::{
     cluster_routing::Routable, from_owned_redis_value, Cmd, ErrorKind, RedisResult, Value,
 };

--- a/glide-core/src/errors.rs
+++ b/glide-core/src/errors.rs
@@ -2,6 +2,8 @@
  * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
  */
 
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use redis::RedisError;
 
 #[repr(C)]

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -1,6 +1,9 @@
-/**
+/*
  * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
  */
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use redis::{cmd, Cmd};
 
 #[cfg(feature = "socket-layer")]

--- a/glide-core/src/retry_strategies.rs
+++ b/glide-core/src/retry_strategies.rs
@@ -1,6 +1,9 @@
-/**
+/*
  * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
  */
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::client::ConnectionRetryStrategy;
 use std::time::Duration;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};

--- a/glide-core/src/rotating_buffer.rs
+++ b/glide-core/src/rotating_buffer.rs
@@ -1,6 +1,9 @@
-/**
+/*
  * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
  */
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use bytes::BytesMut;
 use integer_encoding::VarInt;
 use logger_core::log_error;

--- a/glide-core/src/scripts_container.rs
+++ b/glide-core/src/scripts_container.rs
@@ -1,6 +1,9 @@
-/**
+/*
  * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
  */
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use arcstr::ArcStr;
 use logger_core::log_info;
 use once_cell::sync::Lazy;

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -1,6 +1,9 @@
-/**
+/*
  * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
  */
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use super::rotating_buffer::RotatingBuffer;
 use crate::client::Client;
 use crate::connection_request::ConnectionRequest;

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -113,6 +113,9 @@ pub unsafe extern "system" fn Java_glide_ffi_resolvers_RedisValueResolver_valueF
     redis_value_to_java(&mut env, *value)
 }
 
+/// # Safety
+///
+/// * Function throws a checked java exception if fails to get the socket path.
 #[no_mangle]
 pub unsafe extern "system" fn Java_glide_ffi_resolvers_SocketListenerResolver_startSocketListener<
     'local,

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -102,7 +102,9 @@ fn redis_value_to_java<'local>(env: &mut JNIEnv<'local>, val: Value) -> JObject<
 ///
 /// * `pointer` must point to a valid `Value` obtained from a [protobuf response](https://github.com/aws/glide-for-redis/blob/main/glide-core/src/protobuf/response.proto).
 #[no_mangle]
-pub unsafe extern "system" fn Java_glide_ffi_resolvers_RedisValueResolver_valueFromPointer<'local>(
+pub unsafe extern "system" fn Java_glide_ffi_resolvers_RedisValueResolver_valueFromPointer<
+    'local,
+>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
     pointer: jlong,

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -113,11 +113,8 @@ pub unsafe extern "system" fn Java_glide_ffi_resolvers_RedisValueResolver_valueF
     redis_value_to_java(&mut env, *value)
 }
 
-/// # Safety
-///
-/// * Function throws a checked java exception if fails to get the socket path.
 #[no_mangle]
-pub unsafe extern "system" fn Java_glide_ffi_resolvers_SocketListenerResolver_startSocketListener<
+pub extern "system" fn Java_glide_ffi_resolvers_SocketListenerResolver_startSocketListener<
     'local,
 >(
     env: JNIEnv<'local>,

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -1,6 +1,9 @@
-/**
+/*
  * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
  */
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use glide_core::start_socket_listener;
 
 use jni::objects::{JClass, JObject, JObjectArray, JString, JThrowable};
@@ -95,8 +98,11 @@ fn redis_value_to_java<'local>(env: &mut JNIEnv<'local>, val: Value) -> JObject<
     }
 }
 
+/// # Safety
+///
+/// * `pointer` must point to a valid `Value` obtained from a [protobuf response](https://github.com/aws/glide-for-redis/blob/main/glide-core/src/protobuf/response.proto).
 #[no_mangle]
-pub extern "system" fn Java_glide_ffi_resolvers_RedisValueResolver_valueFromPointer<'local>(
+pub unsafe extern "system" fn Java_glide_ffi_resolvers_RedisValueResolver_valueFromPointer<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
     pointer: jlong,
@@ -106,7 +112,7 @@ pub extern "system" fn Java_glide_ffi_resolvers_RedisValueResolver_valueFromPoin
 }
 
 #[no_mangle]
-pub extern "system" fn Java_glide_ffi_resolvers_SocketListenerResolver_startSocketListener<
+pub unsafe extern "system" fn Java_glide_ffi_resolvers_SocketListenerResolver_startSocketListener<
     'local,
 >(
     env: JNIEnv<'local>,


### PR DESCRIPTION
Add `#![deny(unsafe_op_in_unsafe_fn)]` project-wide: https://doc.rust-lang.org/beta/nightly-rustc/rustc_lint/builtin/static.UNSAFE_OP_IN_UNSAFE_FN.html

I have to update license commment style to avoid
<details>
<summary>compilation errors</summary>

```
error: an inner attribute is not permitted following an outer doc comment
 --> src/lib.rs:5:1
  |
1 | / /**
2 | |  * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
3 | |  */
  | |___- previous doc comment
4 |
5 |   #![deny(unsafe_op_in_unsafe_fn)]
  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not permitted following an outer doc comment
6 |
7 |   use glide_core::start_socket_listener;
  |   -------------------------------------- the inner attribute doesn't annotate this `use` import
  |
  = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
help: to annotate the `use` import, change the attribute from inner to outer style
  |
5 - #![deny(unsafe_op_in_unsafe_fn)]
5 + #[deny(unsafe_op_in_unsafe_fn)]
  |

error: could not compile `glide-rs` (lib) due to previous error
```
</details>