### PR TITLE
Add binary variant to PUBSUB subscribe commands

### DIFF
--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -951,19 +951,21 @@ export class BaseClient {
         let msg: PubSubMsg | null = null;
         const responsePointer = pushNotification.respPointer;
         let nextPushNotificationValue: Record<string, unknown> = {};
+        const isStringDecoder =
+            (decoder ?? this.defaultDecoder) === Decoder.String;
 
         if (responsePointer) {
             if (typeof responsePointer !== "number") {
                 nextPushNotificationValue = valueFromSplitPointer(
                     responsePointer.high,
                     responsePointer.low,
-                    (decoder ?? this.defaultDecoder) === Decoder.String,
+                    isStringDecoder,
                 ) as Record<string, unknown>;
             } else {
                 nextPushNotificationValue = valueFromSplitPointer(
                     0,
                     responsePointer,
-                    (decoder ?? this.defaultDecoder) === Decoder.String,
+                    isStringDecoder,
                 ) as Record<string, unknown>;
             }
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -6815,8 +6815,10 @@ export class BaseClient {
      *
      * @see {@link https://valkey.io/commands/pubsub-channels/|valkey.io} for more details.
      *
-     * @param pattern - A glob-style pattern to match active channels.
-     *                  If not provided, all active channels are returned.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `pattern`: A glob-style pattern to match active channels.
+     *     If not provided, all active channels are returned.
+     * - (Optional) `decoder`: see {@link DecoderOption}.
      * @returns A list of currently active channels matching the given pattern.
      *          If no pattern is specified, all active channels are returned.
      *
@@ -6829,8 +6831,12 @@ export class BaseClient {
      * console.log(newsChannels); // Output: ["news.sports", "news.weather"]
      * ```
      */
-    public async pubsubChannels(pattern?: string): Promise<string[]> {
-        return this.createWritePromise(createPubSubChannels(pattern));
+    public async pubsubChannels(
+        options?: { pattern?: GlideString } & DecoderOption,
+    ): Promise<GlideString[]> {
+        return this.createWritePromise(createPubSubChannels(options?.pattern), {
+            decoder: options?.decoder,
+        });
     }
 
     /**

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -521,9 +521,9 @@ function getRequestErrorClass(
 }
 
 export type PubSubMsg = {
-    message: string;
-    channel: string;
-    pattern?: string | null;
+    message: GlideString;
+    channel: GlideString;
+    pattern?: GlideString | null;
 };
 
 export type WritePromiseOptions = {
@@ -957,13 +957,13 @@ export class BaseClient {
                 nextPushNotificationValue = valueFromSplitPointer(
                     responsePointer.high,
                     responsePointer.low,
-                    decoder === Decoder.String,
+                    (decoder ?? this.defaultDecoder) === Decoder.String,
                 ) as Record<string, unknown>;
             } else {
                 nextPushNotificationValue = valueFromSplitPointer(
                     0,
                     responsePointer,
-                    decoder === Decoder.String,
+                    (decoder ?? this.defaultDecoder) === Decoder.String,
                 ) as Record<string, unknown>;
             }
 
@@ -980,7 +980,9 @@ export class BaseClient {
                 messageKind === "PMessage" ||
                 messageKind === "SMessage"
             ) {
-                const values = nextPushNotificationValue["values"] as string[];
+                const values = nextPushNotificationValue[
+                    "values"
+                ] as GlideString[];
 
                 if (messageKind === "PMessage") {
                     msg = {

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -2207,8 +2207,8 @@ export function createTime(): command_request.Command {
  * @internal
  */
 export function createPublish(
-    message: string,
-    channel: string,
+    message: GlideString,
+    channel: GlideString,
     sharded: boolean = false,
 ): command_request.Command {
     const request = sharded ? RequestType.SPublish : RequestType.Publish;
@@ -3842,7 +3842,7 @@ export function createBLMPop(
  * @internal
  */
 export function createPubSubChannels(
-    pattern?: string,
+    pattern?: GlideString,
 ): command_request.Command {
     return createCommand(RequestType.PubSubChannels, pattern ? [pattern] : []);
 }
@@ -3867,7 +3867,7 @@ export function createPubSubNumSub(
  * @internal
  */
 export function createPubsubShardChannels(
-    pattern?: string,
+    pattern?: GlideString,
 ): command_request.Command {
     return createCommand(RequestType.PubSubSChannels, pattern ? [pattern] : []);
 }

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -851,7 +851,10 @@ export class GlideClient extends BaseClient {
      * console.log(result); // Output: 1 - This message was posted to 1 subscription which is configured on primary node
      * ```
      */
-    public async publish(message: string, channel: string): Promise<number> {
+    public async publish(
+        message: GlideString,
+        channel: GlideString,
+    ): Promise<number> {
         return this.createWritePromise(createPublish(message, channel));
     }
 

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -1222,8 +1222,8 @@ export class GlideClusterClient extends BaseClient {
      * ```
      */
     public async publish(
-        message: string,
-        channel: string,
+        message: GlideString,
+        channel: GlideString,
         sharded: boolean = false,
     ): Promise<number> {
         return this.createWritePromise(
@@ -1237,8 +1237,10 @@ export class GlideClusterClient extends BaseClient {
      *
      * @see {@link https://valkey.io/commands/pubsub-shardchannels/|valkey.io} for details.
      *
-     * @param pattern - A glob-style pattern to match active shard channels.
-     *                  If not provided, all active shard channels are returned.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `pattern`: A glob-style pattern to match active shard channels.
+     *     If not provided, all active shard channels are returned.
+     * - (Optional) `decoder`: see {@link DecoderOption}.
      * @returns A list of currently active shard channels matching the given pattern.
      *          If no pattern is specified, all active shard channels are returned.
      *
@@ -1251,8 +1253,15 @@ export class GlideClusterClient extends BaseClient {
      * console.log(filteredChannels); // Output: ["channel1", "channel2"]
      * ```
      */
-    public async pubsubShardChannels(pattern?: string): Promise<string[]> {
-        return this.createWritePromise(createPubsubShardChannels(pattern));
+    public async pubsubShardChannels(
+        options?: {
+            pattern?: GlideString;
+        } & DecoderOption,
+    ): Promise<GlideString[]> {
+        return this.createWritePromise(
+            createPubsubShardChannels(options?.pattern),
+            { decoder: options?.decoder },
+        );
     }
 
     /**

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -3841,7 +3841,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - A list of currently active channels matching the given pattern.
      *          If no pattern is specified, all active channels are returned.
      */
-    public pubsubChannels(pattern?: string): T {
+    public pubsubChannels(pattern?: GlideString): T {
         return this.addAndReturn(createPubSubChannels(pattern));
     }
 
@@ -4024,7 +4024,7 @@ export class Transaction extends BaseTransaction<Transaction> {
      * Command Response -  Number of subscriptions in primary node that received the message.
      * Note that this value does not include subscriptions that configured on replicas.
      */
-    public publish(message: string, channel: string): Transaction {
+    public publish(message: GlideString, channel: GlideString): Transaction {
         return this.addAndReturn(createPublish(message, channel));
     }
 }
@@ -4151,8 +4151,8 @@ export class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      * Command Response -  Number of subscriptions in primary node that received the message.
      */
     public publish(
-        message: string,
-        channel: string,
+        message: GlideString,
+        channel: GlideString,
         sharded: boolean = false,
     ): ClusterTransaction {
         return this.addAndReturn(createPublish(message, channel, sharded));
@@ -4170,7 +4170,7 @@ export class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      * Command Response - A list of currently active shard channels matching the given pattern.
      *          If no pattern is specified, all active shard channels are returned.
      */
-    public pubsubShardChannels(pattern?: string): ClusterTransaction {
+    public pubsubShardChannels(pattern?: GlideString): ClusterTransaction {
         return this.addAndReturn(createPubsubShardChannels(pattern));
     }
 

--- a/node/tests/PubSub.test.ts
+++ b/node/tests/PubSub.test.ts
@@ -2983,7 +2983,7 @@ describe("PubSub", () => {
 
                     expect(
                         await (publishingClient as GlideClusterClient).publish(
-                            message,
+                            Buffer.from(message),
                             channel,
                             true,
                         ),
@@ -2992,7 +2992,7 @@ describe("PubSub", () => {
                     expect(
                         await (publishingClient as GlideClusterClient).publish(
                             message2,
-                            channel,
+                            Buffer.from(channel),
                             true,
                         ),
                     ).toEqual(1);
@@ -3365,15 +3365,17 @@ describe("PubSub", () => {
                 );
 
                 // Test pubsubChannels with pattern
-                const channelsWithPattern =
-                    await client2.pubsubChannels(pattern);
+                const channelsWithPattern = await client2.pubsubChannels({
+                    pattern,
+                });
                 expect(new Set(channelsWithPattern)).toEqual(
                     new Set([channel1, channel2]),
                 );
 
                 // Test with non-matching pattern
-                const nonMatchingChannels =
-                    await client2.pubsubChannels("non_matching_*");
+                const nonMatchingChannels = await client2.pubsubChannels({
+                    pattern: "non_matching_*",
+                });
                 expect(nonMatchingChannels.length).toBe(0);
             } finally {
                 if (client1) {
@@ -3711,7 +3713,7 @@ describe("PubSub", () => {
                 // Test pubsubShardchannels with pattern
                 const channelsWithPattern = await (
                     client2 as GlideClusterClient
-                ).pubsubShardChannels(pattern);
+                ).pubsubShardChannels({ pattern });
                 expect(new Set(channelsWithPattern)).toEqual(
                     new Set([channel1, channel2]),
                 );
@@ -3719,7 +3721,7 @@ describe("PubSub", () => {
                 // Test with non-matching pattern
                 const nonMatchingChannels = await (
                     client2 as GlideClusterClient
-                ).pubsubShardChannels("non_matching_*");
+                ).pubsubShardChannels({ pattern: "non_matching_*" });
                 expect(nonMatchingChannels).toEqual([]);
             } finally {
                 if (client1) {

--- a/node/tests/PubSub.test.ts
+++ b/node/tests/PubSub.test.ts
@@ -99,12 +99,22 @@ describe("PubSub", () => {
 
         if (clusterMode) {
             try {
-                options.pubsubSubscriptions = pubsubSubscriptions;
-                options.defaultDecoder = decoder;
-                client = await GlideClusterClient.createClient(options);
-                options2.pubsubSubscriptions = pubsubSubscriptions2;
-                options2.defaultDecoder = decoder;
-                const client2 = await GlideClusterClient.createClient(options2);
+                client = await GlideClusterClient.createClient({
+                    pubsubSubscriptions: pubsubSubscriptions,
+                    defaultDecoder: decoder,
+                    ...options,
+                });
+                const client2 = await GlideClusterClient.createClient({
+                    pubsubSubscriptions: pubsubSubscriptions2,
+                    defaultDecoder: decoder,
+                    ...options2,
+                });
+                // options.pubsubSubscriptions = pubsubSubscriptions;
+                // options.defaultDecoder = decoder;
+                // client = await GlideClusterClient.createClient(options);
+                // options2.pubsubSubscriptions = pubsubSubscriptions2;
+                // options2.defaultDecoder = decoder;
+                // const client2 = await GlideClusterClient.createClient(options2);
                 return [client, client2];
             } catch (error) {
                 if (client) {
@@ -115,12 +125,22 @@ describe("PubSub", () => {
             }
         } else {
             try {
-                options.pubsubSubscriptions = pubsubSubscriptions;
-                options.defaultDecoder = decoder;
-                client = await GlideClient.createClient(options);
-                options2.pubsubSubscriptions = pubsubSubscriptions2;
-                options2.defaultDecoder = decoder;
-                const client2 = await GlideClient.createClient(options2);
+                client = await GlideClient.createClient({
+                    pubsubSubscriptions: pubsubSubscriptions,
+                    defaultDecoder: decoder,
+                    ...options,
+                });
+                const client2 = await GlideClient.createClient({
+                    pubsubSubscriptions: pubsubSubscriptions2,
+                    defaultDecoder: decoder,
+                    ...options2,
+                });
+                // options.pubsubSubscriptions = pubsubSubscriptions;
+                // options.defaultDecoder = decoder;
+                // client = await GlideClient.createClient(options);
+                // options2.pubsubSubscriptions = pubsubSubscriptions2;
+                // options2.defaultDecoder = decoder;
+                // const client2 = await GlideClient.createClient(options2);
                 return [client, client2];
             } catch (error) {
                 if (client) {

--- a/node/tests/PubSub.test.ts
+++ b/node/tests/PubSub.test.ts
@@ -374,7 +374,7 @@ describe("PubSub", () => {
 
                 expect(pubsubMessage!.message).toEqual(message);
                 expect(pubsubMessage!.channel).toEqual(channel);
-                expect(pubsubMessage!.pattern).toEqual(null);
+                expect(pubsubMessage!.pattern).toBeNull();
 
                 await checkNoMessagesLeft(method, listeningClient, context, 1);
             } finally {
@@ -389,7 +389,7 @@ describe("PubSub", () => {
     );
 
     /**
-     * Tests the basic happy path for exact PUBSUB functionality with binary decoder.
+     * Tests the basic happy path for exact PUBSUB functionality with binary.
      *
      * This test covers the basic PUBSUB flow using three different methods:
      * Async, Sync, and Callback. It verifies that a message published to a
@@ -460,7 +460,7 @@ describe("PubSub", () => {
 
                 expect(pubsubMessage!.message).toEqual(Buffer.from(message));
                 expect(pubsubMessage!.channel).toEqual(Buffer.from(channel));
-                expect(pubsubMessage!.pattern).toEqual(null);
+                expect(pubsubMessage!.pattern).toBeNull();
 
                 await checkNoMessagesLeft(method, listeningClient, context, 1);
             } finally {

--- a/node/tests/PubSub.test.ts
+++ b/node/tests/PubSub.test.ts
@@ -109,12 +109,6 @@ describe("PubSub", () => {
                     defaultDecoder: decoder,
                     ...options2,
                 });
-                // options.pubsubSubscriptions = pubsubSubscriptions;
-                // options.defaultDecoder = decoder;
-                // client = await GlideClusterClient.createClient(options);
-                // options2.pubsubSubscriptions = pubsubSubscriptions2;
-                // options2.defaultDecoder = decoder;
-                // const client2 = await GlideClusterClient.createClient(options2);
                 return [client, client2];
             } catch (error) {
                 if (client) {
@@ -135,12 +129,6 @@ describe("PubSub", () => {
                     defaultDecoder: decoder,
                     ...options2,
                 });
-                // options.pubsubSubscriptions = pubsubSubscriptions;
-                // options.defaultDecoder = decoder;
-                // client = await GlideClient.createClient(options);
-                // options2.pubsubSubscriptions = pubsubSubscriptions2;
-                // options2.defaultDecoder = decoder;
-                // const client2 = await GlideClient.createClient(options2);
                 return [client, client2];
             } catch (error) {
                 if (client) {


### PR DESCRIPTION
Add binary variant for the following commands:
- `PSubbscribe`
- `Subscribe`
- `SSubscribe`
- `Unsubscribe`
- `SUnsubscribe`
- `PUnsubscribe`

Add decoder option to PUBSUB's `createClient()`.

Note: to complete `PUBSUB` subscribe commands, I have to cherry-pick already merged main branch PR #2201.  